### PR TITLE
Remove `client.json` dependency 

### DIFF
--- a/webapp/spreasheet.py
+++ b/webapp/spreasheet.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import hashlib
 import tempfile
 from googleapiclient.discovery import build
@@ -7,6 +7,8 @@ from google.oauth2 import service_account
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
 SERVICE_ACCOUNT_FILE = "client.json"
+PRIVATE_KEY_ID = os.getenv("PRIVATE_KEY_ID")
+PRIVATE_KEY = os.getenv("PRIVATE_KEY")
 
 
 class DiscoveryCache:
@@ -37,8 +39,20 @@ class DiscoveryCache:
 
 
 def get_sheet():
-    creds = service_account.Credentials.from_service_account_file(
-        SERVICE_ACCOUNT_FILE, scopes=SCOPES
+    service_account_info = {
+        "type": "service_account",
+        "project_id": "roadmap-270011",
+        "private_key_id": PRIVATE_KEY_ID,
+        "private_key": PRIVATE_KEY,
+        "client_email": "specs-reader@roadmap-270011.iam.gserviceaccount.com",
+        "client_id": "112404606310881291739",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/specs-reader%40roadmap-270011.iam.gserviceaccount.com",
+    }
+    creds = service_account.Credentials.from_service_account_info(
+        service_account_info, scopes=SCOPES
     )
     service = build("sheets", "v4", credentials=creds, cache=DiscoveryCache())
 


### PR DESCRIPTION
## Done 

Instead of reading the credentials from a json file:
- Keys are defined as `env` variables
- The rest of the info is defined inline as a dict

## QA

- Create an `env.local` file such as 
```
PRIVATE_KEY_ID=...
PRIVATE_KEY="..." 
```
(Ask me about the keys if you don't have them)

- `dotrun`
- Check specs are displayed on http://0.0.0.0:8104/

## Issue
Fixes #19 