### PR TITLE
add spec details popup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+credentials.json
+token.json
+
 # [generated] Bracketed sections updated by Yeoman generator
 # generator-canonical-webteam@3.4.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ canonicalwebteam.flask-base==1.0.5
 google-api-python-client==1.8.2
 django-openid-auth==0.16
 Flask-OpenID==1.3.0
+beautifulsoup4==4.11.1
+lxml==4.8.0
+python-dateutil==2.8.2
+# TODO: remove this library once we have access to the scope drive.readonly
+google-auth-oauthlib==0.5.1

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -150,10 +150,10 @@ main {
     height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     background-color: $colors--light-theme--background-default;
     .spec-preview {
       overflow: auto;
+      flex: 1;
     }
     .p-button--positive {
       width: fit-content;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -113,3 +113,47 @@ main {
 #no-results {
   grid-column: 1 / -1;
 }
+
+.spec-aside {
+  transition-property: right;
+  position: fixed;
+  top: 0;
+  right: 0;
+  isolation: isolate;
+  height: 100vh;
+  overflow: hidden;
+  &::after {
+    content: "";
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    left: 0;
+    top: 0;
+    background-color: $color-input-shadow;
+  }
+  &.hide {
+    right: -100%;
+    &::after {
+      display: none;
+    }
+  }
+  .spec-container {
+    padding: $spv--large $sph--large;
+    position: relative;
+    z-index: 1;
+    max-width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background-color: $colors--light-theme--background-default;
+    .spec-preview {
+      overflow: auto;
+    }
+    .p-button--positive {
+      width: fit-content;
+      margin-left: auto;
+      margin-top: $spv--medium;
+    }
+  }
+}

--- a/templates/_spec_details.html
+++ b/templates/_spec_details.html
@@ -1,0 +1,68 @@
+<aside class="spec-aside l-aside hide">
+  <div class="spec-container">
+    <section class="p-strip is-bordered is-shallow">
+      <small class="spec-card__metadata-list">
+        <ul class="header p-inline-list--middot u-no-margin--bottom">
+          <!-- li: index -->
+          <!-- li: folderName -->
+          <!-- li: type -->
+        </ul>
+      </small>
+      <button class="p-modal__close" aria-label="Close spec preview">
+        Close
+      </button>
+    </section>
+    <section class="spec-metadata p-strip is-bordered is-shallow">
+      <h3 class="title"></h3>
+      <small
+        >Authors: <em class="authors"></em>
+        <br />
+        Created: <em class="created"></em>
+        <br />
+      </small>
+    </section>
+    <section class="spec-preview"></section>
+    <a class="p-button--positive" href="#">Open in Google Docs</a>
+  </div>
+  <script>
+    const currentElement = document.currentScript.parentElement;
+    // setup cards preview
+    const links = document.querySelectorAll(".spec-card__content a");
+    links.forEach((link) =>
+      link.addEventListener("click", (e) => {
+        e.preventDefault();
+        let documentId = e.target.href.match(
+          /.*docs.google.com\/document\/d\/(?<documentId>.+)/
+        ).groups.documentId;
+        documentId = documentId.split("/")[0];
+        if (documentId) {
+          loadContent(documentId);
+        }
+      })
+    );
+
+    currentElement
+      .querySelector(".p-modal__close")
+      .addEventListener("click", () => currentElement.classList.add("hide"));
+    function loadContent(documentId) {
+      fetch("/spec/" + documentId)
+        .then((response) => response.json())
+        .then((spec) => {
+          currentElement.classList.remove("hide");
+          const specContainer = currentElement.querySelector(".spec-container");
+          specContainer.querySelector(".header").innerHTML = `
+          <li class="p-inline-list__item">${spec.metadata.index}</li>
+          <li class="p-inline-list__item">${spec.metadata.type}</li>
+        `;
+          specContainer.querySelector(".spec-preview").innerHTML = spec.html;
+          specContainer.querySelector(".title").innerHTML = spec.metadata.title;
+          specContainer.querySelector(".authors").innerHTML =
+            spec.metadata.authors.join(", ");
+          // specContainer.querySelector(".contributors").innerHTML =
+          // spec.metadata.authors.join(", ");
+          specContainer.querySelector(".created").innerHTML =
+            spec.metadata.created.toLocaleString();
+        });
+    }
+  </script>
+</aside>

--- a/templates/_spec_details.html
+++ b/templates/_spec_details.html
@@ -1,4 +1,4 @@
-<aside class="spec-aside l-aside hide">
+<aside class="spec-aside l-aside is-wide hide">
   <div class="spec-container">
     <section class="p-strip is-bordered is-shallow">
       <small class="spec-card__metadata-list">
@@ -8,23 +8,21 @@
           <!-- li: type -->
         </ul>
       </small>
-      <button class="p-modal__close" aria-label="Close spec preview">
-        Close
-      </button>
+      <button class="p-modal__close" aria-label="Close spec preview">Close</button>
     </section>
     <section class="spec-metadata p-strip is-bordered is-shallow">
       <h3 class="title"></h3>
-      <small
-        >Authors: <em class="authors"></em>
-        <br />
-        Created: <em class="created"></em>
-        <br />
-      </small>
-    </section>
-    <section class="spec-preview"></section>
-    <a class="p-button--positive" href="#">Open in Google Docs</a>
-  </div>
-  <script>
+      <small >Authors: <em class="authors"></em>
+      <br />
+      Created: <em class="created"></em>
+      <br />
+    </small>
+  </section>
+  <section class="spec-preview">
+  </section>
+  <a class="p-button--positive spec-link" href="#" role="button">Open in Google Docs</a>
+</div>
+<script>
     const currentElement = document.currentScript.parentElement;
     // setup cards preview
     const links = document.querySelectorAll(".spec-card__content a");
@@ -58,11 +56,10 @@
           specContainer.querySelector(".title").innerHTML = spec.metadata.title;
           specContainer.querySelector(".authors").innerHTML =
             spec.metadata.authors.join(", ");
-          // specContainer.querySelector(".contributors").innerHTML =
-          // spec.metadata.authors.join(", ");
           specContainer.querySelector(".created").innerHTML =
             spec.metadata.created.toLocaleString();
+          specContainer.querySelector(".spec-link").href = spec.url;
         });
     }
-  </script>
+</script>
 </aside>

--- a/templates/index.html
+++ b/templates/index.html
@@ -49,4 +49,5 @@
   {% for spec in specs %} {% with spec=spec %} {% include "_card.html" %} {%
   endwith %} {% endfor %}
 </div>
+{% include "_spec_details.html" %}
 {% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -106,4 +106,10 @@ def index():
 @app.route("/spec/<document_id>")
 def spec_details(document_id):
     spec = Spec(google_drive, document_id)
-    return flask.jsonify({"metadata":spec.metadata, "html":spec.html.encode("utf-8").decode()})
+    return flask.jsonify(
+        {
+            "metadata": spec.metadata,
+            "url": spec.url,
+            "html": spec.html.encode("utf-8").decode(),
+        }
+    )

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import flask
 from canonicalwebteam.flask_base.app import FlaskBase
 from webapp.authors import parse_authors, unify_authors
+from webapp.spec import GoogleDrive, Spec
 
 from webapp.spreasheet import get_sheet
 from webapp.sso import init_sso
@@ -16,7 +17,7 @@ SPECS_API = f"https://script.google.com/macros/s/{DEPLOYMENT_ID}/exec"
 
 SPREADSHEET_ID = "1jFj4z19cXZaPZcZk8nPTPmeO0zBbja5Bg23eXiZr9Pw"
 sheet = get_sheet()
-
+google_drive = GoogleDrive()
 
 app = FlaskBase(
     __name__,
@@ -100,3 +101,9 @@ def index():
     teams = sorted(teams)
 
     return flask.render_template("index.html", specs=specs, teams=teams)
+
+
+@app.route("/spec/<document_id>")
+def spec_details(document_id):
+    spec = Spec(google_drive, document_id)
+    return flask.jsonify({"metadata":spec.metadata, "html":spec.html.encode("utf-8").decode()})

--- a/webapp/spec.py
+++ b/webapp/spec.py
@@ -1,0 +1,96 @@
+import io
+import os
+
+from apiclient.http import MediaIoBaseDownload
+from bs4 import BeautifulSoup
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+from webapp.spreasheet import DiscoveryCache
+from dateutil.parser import parse
+
+class GoogleDrive:
+    def __init__(self):
+        scopes = [
+            "https://www.googleapis.com/auth/drive.readonly",
+        ]
+        creds = None
+        # The file token.json stores the user's access and refresh tokens, and is
+        # created automatically when the authorization flow completes for the first
+        # time.
+        if os.path.exists("token.json"):
+            creds = Credentials.from_authorized_user_file("token.json", scopes)
+        # If there are no (valid) credentials available, let the user log in.
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    "credentials.json", scopes
+                )
+                creds = flow.run_local_server(port=60889)
+            # Save the credentials for the next run
+            with open("token.json", "w") as token:
+                token.write(creds.to_json())
+        self.service = build(
+            "drive", "v2", credentials=creds, cache=DiscoveryCache()
+        )
+
+    def doc_html(self, document_id):
+        request = self.service.files().export_media(
+            fileId=document_id, mimeType="text/html"
+        )
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request)
+        done = False
+        while done is False:
+            _, done = downloader.next_chunk()
+        html = fh.getvalue().decode("utf-8")
+        comments = self.service.comments().list(fileId=document_id).execute().get("items", [])
+        return html, comments
+
+
+class Spec:
+    html:BeautifulSoup
+    metadata = {"index": "","title":"", "status":"", "authors":[], "type":"", "created":""}
+    def __init__(self, google_drive: GoogleDrive, document_id: str):
+        raw_html, comments = google_drive.doc_html(document_id)
+        self.html = BeautifulSoup(raw_html, features="lxml")
+        self.clean()
+        self.parse_metadata()
+    def clean(self):
+        empty_tags_selector = lambda tag: (not tag.contents or len(tag.get_text(strip=True)) <= 0) and tag.name not in ["br", "img", "hr"]
+        for element in self.html.findAll(empty_tags_selector):
+            element.decompose()
+
+    def parse_metadata(self):
+        table = self.html.select_one("table")
+        for table_row in table.select("tr"):
+            cells = table_row.select("td")
+            # invalid format | name | value |, ignoring the row
+            if len(cells) != 2:
+                continue
+            attr_name, attr_value = cells
+            attr_name = attr_name.text.lower().strip()
+            attr_value = attr_value.text.strip()
+            attr_value_lower_case = attr_value.lower()
+            if attr_name in self.metadata:
+                if attr_name in ["index", "title"]:
+                    self.metadata[attr_name] = attr_value
+                elif attr_name == "status":
+                    if attr_value_lower_case in ["approved","pending review","drafting","braindump","unknown"]:
+                        self.metadata["status"] = attr_value_lower_case
+                    else:
+                        self.metadata["status"] = "unknown"
+                elif attr_name == "authors":
+                    self.metadata["authors"] = [author.strip() for author in attr_value.split(',')]
+                elif attr_name=="type":
+                    if attr_value_lower_case in ["standard","informational","process"]:
+                        self.metadata['type'] = attr_value_lower_case
+                    else:
+                        self.metadata["type"] = "unknown"
+                elif attr_name == "created":
+                    self.metadata['created'] = parse(attr_value_lower_case)
+        table.decompose()


### PR DESCRIPTION
## Done

- add a new API endpoint `/spec/<document-id>`: returns the document html and some metadata
- add a new view that can be showed by clicking on a spec card title

## QA

- As we don't have access to docs, you need to login
  - the app credentials: `credentials.json` (I can share this file with you)
- Start the project `dotrun`
- Login to you Google account
- Click on a spec card title
- Make sure that there is a spec details view
- Click on the close button
- Make sure that it's closed
- Click on another spec card title
- Make sure that the view is updated

## Screenshots

### the spec details view
![Untitled](https://user-images.githubusercontent.com/36013798/167163803-57b603d9-e672-49c4-ac88-0cb75a8631c7.png)
