### PR TITLE
Change chips for status labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,7 @@ env[23]/
 *.css
 api.launchpad.net
 
+# credentials
 client.json
+token.json
+credentials.json

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,11 +28,6 @@ main {
   margin: 0;
 }
 
-.spec-card__status-label-container {
-  flex-shrink: 0;
-  margin-left: $sph--small;
-}
-
 .spec-card--drafting,
 .spec-card--braindump {
   border-top-color: $color-mid-dark !important;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,7 +28,7 @@ main {
   margin: 0;
 }
 
-.spec-card__chip-container {
+.spec-card__status-label-container {
   flex-shrink: 0;
   margin-left: $sph--small;
 }

--- a/templates/_card.html
+++ b/templates/_card.html
@@ -19,17 +19,17 @@
             </li>
           </ul>
         </small>
-        <div class="spec-card__chip-container">
+        <div class="spec-card__status-label-container">
           {% if spec.status == "Approved" or spec.status == "Completed" or spec.status == "Active" %}
-            <div class="p-chip--positive u-no-margin">{{ spec.status }}</div>
+            <div class="p-status-label--positive u-no-margin">{{ spec.status }}</div>
           {% elif spec.status == "Pending Review" %}
-            <div class="p-chip--caution u-no-margin">Pending Review</div>
+            <div class="p-status-label--caution u-no-margin">Pending Review</div>
           {% elif spec.status == "Drafting" or spec.status == "Braindump" %}
-            <div class="p-chip u-no-margin">{{ spec.status }}</div>
+            <div class="p-status-label u-no-margin">{{ spec.status }}</div>
           {% elif spec.status == "Rejected" or spec.status == "Obsolete" %}
-            <div class="p-chip--negative u-no-margin">{{ spec.status }}</div>
+            <div class="p-status-label--negative u-no-margin">{{ spec.status }}</div>
           {% else %}
-            <div class="p-chip--negative u-no-margin">Unknown</div>
+            <div class="p-status-label--negative u-no-margin">Unknown</div>
           {% endif %}
         </div>
       </div>

--- a/templates/_card.html
+++ b/templates/_card.html
@@ -19,7 +19,7 @@
             </li>
           </ul>
         </small>
-        <div class="spec-card__status-label-container">
+        <div>
           {% if spec.status == "Approved" or spec.status == "Completed" or spec.status == "Active" %}
             <div class="p-status-label--positive u-no-margin">{{ spec.status }}</div>
           {% elif spec.status == "Pending Review" %}


### PR DESCRIPTION
## Done

Since they're not clickable, it makes more sense to use status labels instead of chips.
See discussion here #65 

## QA

- Open demo or `dotrun`
- Check the status labels look alright

## Issue 
Fixes #65 