### PR TITLE
Don't be pedantic about case of "Pending Review"

### DIFF
--- a/templates/_card.html
+++ b/templates/_card.html
@@ -2,7 +2,7 @@
   <div class="spec-card spec-card--{{ spec.status|lower }} p-card col-4 u-no-padding"
        data-authors="{{ spec.authors }}"
        data-index="{{ spec.index or 'unknown' }}"
-       data-status="{{ spec.status or 'unknown' }}"
+       data-status="{{ spec.status.title() or 'unknown' }}"
        data-team="{{ spec.folderName }}"
        data-title="{{ (spec.title or "Unknown title") | trim }}"
        data-type="{{ spec.type }}"
@@ -22,7 +22,7 @@
         <div>
           {% if spec.status == "Approved" or spec.status == "Completed" or spec.status == "Active" %}
             <div class="p-status-label--positive u-no-margin">{{ spec.status }}</div>
-          {% elif spec.status == "Pending Review" %}
+          {% elif spec.status.title() == "Pending Review" %}
             <div class="p-status-label--caution u-no-margin">Pending Review</div>
           {% elif spec.status == "Drafting" or spec.status == "Braindump" %}
             <div class="p-status-label u-no-margin">{{ spec.status }}</div>


### PR DESCRIPTION
Be more permissive of "Pending review" status[^1]

This promotes ~6 specs from out of the dreaded Unknown status - compare [staging](https://specs.staging.canonical.com/)'s 58 with [demo.haus](https://specs-canonical-com-76.demos.haus/)' 52 Unknown.

[^1]: going forward this should almost definitely **not** be logic inside of a template