### PR TITLE
fix(client): Add Pending Review

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -15,6 +15,7 @@ export const specStatuses = new Set([
   "drafting",
   "obsolete",
   "pending approval",
+  "pending review",
   "rejected",
 ]);
 function App({ specs, teams }: { specs: Spec[]; teams: Team[] }) {


### PR DESCRIPTION
as per the Canonical spec on specs, Pending Review is a valid state. No
need to change the card, as it already checks for startsWith("pending").