### PR TITLE
fix spec card's status oversize

### DIFF
--- a/client/SpecCard.tsx
+++ b/client/SpecCard.tsx
@@ -17,7 +17,7 @@ const SpecCard = ({ spec }: { spec: Spec }) => {
               </ul>
             </small>
             <div
-              className={clsx("u-no-margin", {
+              className={clsx("spec-card__status u-no-margin", {
                 "p-status-label--positive":
                   spec.status === "Approved" ||
                   spec.status === "Completed" ||

--- a/client/styles.scss
+++ b/client/styles.scss
@@ -21,7 +21,9 @@ main {
   display: flex;
   justify-content: space-between;
 }
-
+.spec-card__status {
+  height: fit-content;
+}
 .spec-card__metadata-list {
   align-self: center;
   flex-grow: 1;


### PR DESCRIPTION
## Done

- fix spec card status oversize


## QA

- Go to https://specs-canonical-com-89.demos.haus/?filter%5Bteam%5D=all&filter%5Bstatus%5D%5B0%5D=Pending%20review&filter%5Bstatus%5D%5B1%5D=Pending%20approval&filter%5Bauthor%5D=all&filter%5BsortBy%5D=date&searchQuery=
- Search for "OB016" make sure that the status has the correct size


## Screenshots

### Before :-1: 
![Screenshot from 2022-08-08 19-41-19](https://user-images.githubusercontent.com/36013798/183480365-7619f655-0568-4dd8-bbb4-51993604492d.png)

### After :+1: 
![image](https://user-images.githubusercontent.com/36013798/183480385-58bcabe9-83e2-42c0-9560-f73f58521d14.png)

