### PR TITLE
[client/SpecDetails] fix: don't name the target to load the spec in

### DIFF
--- a/client/SpecsDetails.tsx
+++ b/client/SpecsDetails.tsx
@@ -161,7 +161,7 @@ const SpecsDetails: React.FC<SpecDetailsProps> = ({
                   <a
                     className="p-button--positive spec-link"
                     href={specDetails.url}
-                    target="blank"
+                    target="_blank"
                   >
                     Open in Google Docs
                   </a>


### PR DESCRIPTION
Fix the name of the <a target=...> from the spec preview to avoid replacing contents of the tab