### PR TITLE
preserve default anchor behaviour

### DIFF
--- a/client/SpecCard.tsx
+++ b/client/SpecCard.tsx
@@ -51,10 +51,16 @@ const SpecCard = ({ spec }: { spec: Spec }) => {
             </div>
             <h3 className="p-heading--4 u-no-margin--bottom">
               <a
-                role="button"
-                onClick={() => setViewSpecsDetails(true)}
+                href={spec.fileURL}
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey) {
+                    return;
+                  } else {
+                    e.preventDefault();
+                    setViewSpecsDetails(true);
+                  }
+                }}
                 onKeyDown={handleKeyDown}
-                tabIndex={0}
               >
                 {spec.title}
               </a>


### PR DESCRIPTION
## Done
- preserve default anchor behaviour (allows to open a link in a new tab)

## QA
Click on a spec link and verify a card is opened
cmd/ctrl + click and verify a destination link has been opened in a new tab