### PR TITLE
feat: automatically turn spec_name to uppercase

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -111,7 +111,7 @@ def index():
 @app.route("/spec/<spec_name>")
 def spec(spec_name):
     for spec in _generate_specs():
-        if spec_name == spec["index"]:
+        if spec_name.upper() == spec["index"]:
             return redirect(spec["fileURL"])
     else:
         abort(404)


### PR DESCRIPTION
It seems that team names abbreviation used in the spec name is always uppercase.
For the lazy-ones this will turn spec name to the uppercase, so both `/spec/ma001` and `/spec/MA001` will work.