### PR TITLE
feat: add a new spec link to docs

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -51,6 +51,12 @@ function App({ specs, teams }: { specs: Spec[]; teams: Team[] }) {
           height: "19",
           url: "/",
         }}
+        itemsRight={[
+          {
+            url: "https://docs.google.com/document/d/1o0uqbarAch4guwXZhLpv04DK18J9704L_p7fzAdE6CE/edit#heading=h.31hys4te5m58",
+            label: "Add a new spec",
+          },
+        ]}
         theme={Theme.DARK}
       />
       <main className="l-fluid-breakout" id="main">

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -54,7 +54,7 @@ function App({ specs, teams }: { specs: Spec[]; teams: Team[] }) {
         itemsRight={[
           {
             url: "https://docs.google.com/document/d/1o0uqbarAch4guwXZhLpv04DK18J9704L_p7fzAdE6CE/edit#heading=h.31hys4te5m58",
-            label: "Add a new spec",
+            label: "How to add a new spec",
           },
         ]}
         theme={Theme.DARK}


### PR DESCRIPTION
## Done
- add a new spec with a link to docs

Fixes: https://github.com/canonical/specs.canonical.com/issues/25

## QA steps
- Click the "Add a new spec" link
- Verify it links to the google docs guide document

## Screenshots
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/7452681/203791747-8176c49c-fdd5-4d24-820c-b6783b97be8f.png">
