### PR TITLE
Remove 1000 limit when reading specs from the sheet WD-977

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -58,7 +58,7 @@ def is_spec(row):
 
 
 def _generate_specs():
-    RANGE = "A2:M1000"
+    RANGE = "A2:M"
     COLUMNS = [
         ("folderName", str),
         ("fileName", str),


### PR DESCRIPTION
## Done

Modify the range to read all rows in the sheet (it was caped at 1000, which meant that only 999 specs were rendered)

## QA

- Open demo
- Are there more than 1000 specs?

