### PR TITLE
bugfix(server): Match specs_statuses

### DIFF
--- a/webapp/spec.py
+++ b/webapp/spec.py
@@ -7,13 +7,15 @@ from webapp.google import Drive
 
 
 specs_status = (
-    "braindump",
-    "drafting",
-    "pending review",
+    "active",
     "approved",
-    "rejected",
+    "braindump",
     "completed",
+    "drafting",
     "obsolete",
+    "pending approval",
+    "pending review",
+    "rejected",
 )
 
 spec_types = (


### PR DESCRIPTION
Fixes #120

Client code in App.tsx and server code in spec.py did not have matching definitions of specs_status. In #87, we addressed missing specs on the Client side, but my previous work missed the Server side. This copies the specs_status from App.tsx into spec.py