### PR TITLE
Run update cronjob less often

### DIFF
--- a/konf/cronjob-update.yaml
+++ b/konf/cronjob-update.yaml
@@ -1,5 +1,5 @@
 name: cronjob-update-spreadsheet
-schedule: "0 * * * *"
+schedule: "0 */3 * * *"
 image: prod-workplace-eng.docker-registry.canonical.com/cronjob-update-spreadsheet
 
 env:


### PR DESCRIPTION
## Done

The spreadsheet got in a [wrong state](https://sentry.is.canonical.com/canonical/specs-canonical-com/issues/31423/). Currently the update script takes a long time to run (~~there are more than 2000 specs~~ not really, there are duplicates), so I can see it happening if the cronjob starts running before the previous one has finished.

Run it every 3 hours instead of every hour.