### PR TITLE
WD-2246 Render an index of a spec which is longer then 5 characters

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -22,7 +22,7 @@ function App({ specs, teams }: { specs: Spec[]; teams: Team[] }) {
   specs = specs.map((spec) => ({
     ...spec,
     title: spec.title || "Unknown title",
-    index: spec.index?.length === 5 ? spec.index : "Unknown",
+    index: spec.index?.length >= 5 ? spec.index : "Unknown",
     status: specStatuses.has(spec.status.toLowerCase())
       ? spec.status
       : "Unknown",

--- a/client/SpecCard.tsx
+++ b/client/SpecCard.tsx
@@ -32,18 +32,19 @@ const SpecCard = ({ spec }: { spec: Spec }) => {
               <div
                 className={clsx("spec-card__status u-no-margin", {
                   "p-status-label--positive":
-                    spec.status === "Approved" ||
-                    spec.status === "Completed" ||
-                    spec.status === "Active",
+                    spec.status.toLowerCase() === "approved" ||
+                    spec.status.toLowerCase() === "completed" ||
+                    spec.status.toLowerCase() === "active",
                   "p-status-label--caution": spec.status
                     .toLowerCase()
                     .startsWith("pending"),
                   "p-status-label":
-                    spec.status === "Drafting" || spec.status === "Braindump",
+                    spec.status.toLowerCase() === "drafting" ||
+                    spec.status.toLowerCase() === "braindump",
                   "p-status-label--negative":
-                    spec.status === "Rejected" ||
-                    spec.status === "Obsolete" ||
-                    spec.status === "Unknown",
+                    spec.status.toLowerCase() === "rejected" ||
+                    spec.status.toLowerCase() === "obsolete" ||
+                    spec.status.toLowerCase() === "unknown",
                 })}
               >
                 {spec.status}

--- a/client/tests/SpecCard.test.tsx
+++ b/client/tests/SpecCard.test.tsx
@@ -14,8 +14,10 @@ describe("renders spec card component", () => {
     expect(specTitle).toBeInTheDocument();
     const comments = screen.getByText("10 comments 5 unresolved");
     expect(comments).toBeInTheDocument();
-    const specIndex = screen.getByText("index");
+    const specIndex = screen.getByText("AB123");
     expect(specIndex).toBeInTheDocument();
+    const specStatus = screen.getByText("active");
+    expect(specStatus).toBeInTheDocument();
   });
 
   it("opens the spec preview on click of the spec title", async () => {
@@ -32,5 +34,28 @@ describe("renders spec card component", () => {
     const specPreview: any =
       SpecCardComponent.container.querySelector(".spec-aside");
     expect(specPreview).toBeInTheDocument();
+  });
+});
+
+describe("renders spec card with edgecases", () => {
+  let SpecCardComponent: any;
+  let testSpecClone: any;
+
+  beforeEach(() => {
+    testSpecClone = { ...testSpec };
+  });
+
+  it("shows a long index", async () => {
+    testSpecClone.index = "ABC12345";
+    SpecCardComponent = render(<SpecCard spec={testSpecClone} />);
+    const specIndex = screen.getByText("ABC12345");
+    expect(specIndex).toBeInTheDocument();
+  });
+
+  it("shows lowercase statuses", async () => {
+    testSpecClone.status = "active";
+    SpecCardComponent = render(<SpecCard spec={testSpecClone} />);
+    const specStatus = screen.getByText("active");
+    expect(specStatus).toHaveClass("p-status-label--positive");
   });
 });

--- a/client/tests/__mocks__/utils.ts
+++ b/client/tests/__mocks__/utils.ts
@@ -9,7 +9,7 @@ export const moreSpecTestDetails: MoreSpecDetails = {
 const testMetadata: Metadata = {
   authors: ["test_author"],
   created: new Date(),
-  index: "index",
+  index: "AB123",
   status: "active",
   title: "test_title",
   type: "Process",


### PR DESCRIPTION
## Done
- Changed the logic to render indexes that are not exactly 5 characters
- Drive by, to fix lowercase status badges
- Added tests for both

## QA
1. Pull this branch
2. If you need creds ask me
3. Run `dotrun` and open the site locally
4. See that the spec titled "Written Interview" shows its index at the top right of the card
5. Run `dotrun js-test` and ensure they all pass