### PR TITLE
WD-2332 Improve unknown spec status reporting

### DIFF
--- a/client/SpecsDetails.tsx
+++ b/client/SpecsDetails.tsx
@@ -4,6 +4,8 @@ import { Spinner } from "@canonical/react-components";
 import { SpecDetails, Metadata, MoreSpecDetails } from "./types";
 import FocusTrap from "focus-trap-react";
 import ErrorComponent from "./Error";
+import { specStatuses } from "./App";
+import { capitalize } from "./utils";
 
 interface SpecDetailsProps {
   moreSpecDetails: MoreSpecDetails;
@@ -134,6 +136,7 @@ const SpecsDetails: React.FC<SpecDetailsProps> = ({
                     >
                       {specDetails.metadata.status}
                     </div>
+                    {unknownStatusMessage(specDetails.metadata.statusMessage)}
                   </span>
                   <p className="u-no-padding--top">
                     Authors:{" "}
@@ -180,5 +183,24 @@ const SpecsDetails: React.FC<SpecDetailsProps> = ({
     </FocusTrap>
   );
 };
+
+function unknownStatusMessage(
+  statusMessage: string | undefined
+): JSX.Element | null {
+  if (!statusMessage) {
+    return null;
+  }
+  const statuses = [...specStatuses];
+  return (
+    <div className="u-text--muted" data-testid="unknown-status-message">
+      <i className="p-icon--warning" /> Your status is "{statusMessage}", it
+      should be one of{" "}
+      {statuses.map(
+        (status, index) =>
+          `${capitalize(status)}${index < statuses.length - 1 ? ", " : "."}`
+      )}
+    </div>
+  );
+}
 
 export default SpecsDetails;

--- a/client/tests/SpecDetails.test.tsx
+++ b/client/tests/SpecDetails.test.tsx
@@ -96,4 +96,37 @@ describe("renders spec details component", () => {
     const errorPrompt = screen.getByText("Error. Something went wrong.");
     expect(errorPrompt).toBeInTheDocument();
   });
+
+  it("does not displays a warning message when status is set", async () => {
+    await act(async () => {
+      render(SpecDetailsComp);
+    });
+
+    expect(screen.getByText("active")).toBeInTheDocument();
+    expect(() => screen.getByTestId("unknown-status-message")).toThrow(
+      "Unable to find an element"
+    );
+  });
+
+  it("displays a warning message for 'unknown' statuses", async () => {
+    await act(async () => {
+      console.log(testSpecDetails);
+      const specDetails = testSpecDetails;
+      specDetails.metadata.status = "unknown";
+      specDetails.metadata.statusMessage = "Incorrect";
+
+      render(
+        <SpecsDetails
+          moreSpecDetails={moreSpecTestDetails}
+          viewSpecsDetails={true}
+          setViewSpecsDetails={setViewSpecsDetails}
+        />
+      );
+    });
+
+    const status = screen.getByText("unknown");
+    expect(status).toBeInTheDocument();
+    const warning = screen.getByTestId("unknown-status-message");
+    expect(warning).toBeInTheDocument();
+  });
 });

--- a/client/types.ts
+++ b/client/types.ts
@@ -15,6 +15,7 @@ export type Spec = {
 };
 
 export type Metadata = {
+  statusMessage: string | undefined;
   authors: [string];
   created: Date;
   index: string;

--- a/webapp/spec.py
+++ b/webapp/spec.py
@@ -88,6 +88,7 @@ class Spec:
                         self.metadata["status"] = attr_value
                     else:
                         self.metadata["status"] = "unknown"
+                        self.metadata["statusMessage"] = attr_value
                 elif attr_name == "authors":
                     self.metadata["authors"] = [
                         author.strip() for author in attr_value.split(",")

--- a/webapp/update.py
+++ b/webapp/update.py
@@ -64,7 +64,6 @@ def update_sheet() -> None:
                 "webViewLink",
             ),
         )
-
         for file in files:
             comments = drive.get_comments(
                 file_id=file["id"], fields=("resolved",)


### PR DESCRIPTION
## Done

- Saved the unknown status and rendered a warning message in the details panel of the spec
- Added a few tests to cover the conditional functionality

## QA

1. Pull this branch and ask me for support if needed to get running locally
2. Run `dotrun` and visit http://localhost:8104/
3. Look for a spec with an Unknown status and open the details
4. See the warning message in the head detailing what the status is and what set it should be
5. Open the details for a known status spec and see there is no warning
6. Run `dotrun test-js` and ensure they all pass

## Screenshots

| Before | After |
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/1413534/221851848-4c6b2ff0-76be-4351-ba18-aefde46828df.png) | ![image](https://user-images.githubusercontent.com/1413534/221851895-7c38ec32-fea6-49df-ad26-1e8c35571306.png) |