### PR TITLE
generate specs at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ ENV PATH="/root/.local/bin:${PATH}"
 RUN rm -rf package.json yarn.lock .babelrc webpack.config.js requirements.txt
 COPY --from=frontend-build /srv/static static
 
+# Build specs json file 
+ARG PRIVATE_KEY
+ARG PRIVATE_KEY_ID
+RUN python3 -m webapp.build_specs
+
 # Set git commit ID
 ARG BUILD_ID
 ENV TALISKER_REVISION_ID "${BUILD_ID}"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "yarn run lint-python && yarn run test-python",
     "test-python": "python3 -m unittest discover tests",
     "test-js": "jest --silent",
-    "test-coverage-js": "jest --coverage --silent"
+    "test-coverage-js": "jest --coverage --silent",
+    "build-specs": "python3 -m webapp.build_specs"
   },
   "dependencies": {
     "@canonical/react-components": "0.38.0",

--- a/webapp/build_specs.py
+++ b/webapp/build_specs.py
@@ -1,0 +1,75 @@
+import json
+from datetime import datetime
+
+from webapp.google import Sheets
+from webapp.settings import TRACKER_SPREADSHEET_ID, SPECS_SHEET_TITLE
+
+
+def get_value_row(row, type):
+    if row:
+        if type == datetime:
+            if "formattedValue" in row:
+                return datetime.strptime(
+                    row["formattedValue"], "%Y-%m-%dT%H:%M:%S.%fZ"
+                ).strftime("%d %b %Y")
+        elif "userEnteredValue" in row:
+            if "stringValue" in row["userEnteredValue"]:
+                return type(row["userEnteredValue"]["stringValue"])
+            if "numberValue" in row["userEnteredValue"]:
+                return type(row["userEnteredValue"]["numberValue"])
+
+    return ""
+
+def index_in_list(a_list, index):
+    return index < len(a_list)
+
+
+def is_spec(row):
+    """Check that file name exists."""
+
+    return "userEnteredValue" in row[1]
+
+def generate_specs(sheet):
+    COLUMNS = [
+        ("folderName", str),
+        ("fileName", str),
+        ("fileID", str),
+        ("fileURL", str),
+        ("index", str),
+        ("title", str),
+        ("status", str),
+        ("authors", str),
+        ("type", str),
+        ("created", datetime),
+        ("lastUpdated", datetime),
+        ("numberOfComments", int),
+        ("openComments", int),
+    ]
+
+    for row in sheet["data"][0]["rowData"]:
+        if "values" in row and is_spec(row["values"]):
+            spec = {}
+            for column_index in range(len(COLUMNS)):
+                (column, type) = COLUMNS[column_index]
+                spec[column] = get_value_row(
+                    row["values"][column_index]
+                    if index_in_list(row["values"], column_index)
+                    else None,
+                    type,
+                )
+            yield spec
+
+
+if __name__ == "__main__":
+    spreadsheet = Sheets(spreadsheet_id=TRACKER_SPREADSHEET_ID) 
+    
+    RANGE = "A2:M" 
+    sheet = spreadsheet.get_sheet_by_title(
+        title=SPECS_SHEET_TITLE, ranges=[f"{SPECS_SHEET_TITLE}!{RANGE}"]
+    )
+    
+    specs = list(generate_specs(sheet))
+
+    with open("specs.json", "w") as f:
+        json.dump(specs, f, indent=4)
+

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -2,7 +2,7 @@ import os
 
 
 PRIVATE_KEY_ID = os.getenv("PRIVATE_KEY_ID")
-PRIVATE_KEY = os.getenv("PRIVATE_KEY")
+PRIVATE_KEY = os.getenv("PRIVATE_KEY").replace("\\n", "\n")
 SERVICE_ACCOUNT_INFO = {
     "type": "service_account",
     "project_id": "roadmap-270011",


### PR DESCRIPTION
## Done

Read the spreadsheet when building the docker image and generate a json file, which will be used to render the specs.

This is an alternative to reading the spreadsheet directly in the deployed application.

## QA

- Run `dotrun build-specs` to generate the json file
- `dotrun`
