### PR TITLE
check if the specs file exists

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,6 +1,6 @@
-import json
 import copy 
-
+import json
+import os
 
 from flask import render_template, jsonify, abort, redirect
 from canonicalwebteam.flask_base.app import FlaskBase
@@ -26,8 +26,11 @@ app = FlaskBase(
 
 init_sso(app)
 
-with open("specs.json") as f:
-    all_specs = json.load(f)
+SPECS_FILE = "specs.json"
+if os.path.exists(SPECS_FILE):
+    with open(SPECS_FILE) as f:
+        all_specs = json.load(f)
+
 
 @app.route("/")
 def index():


### PR DESCRIPTION
## Done

Add a check to see if `specs.json` exists. The reason is that we use this for the update script as well, which doesn't require the list of specs.

## QA
- Generate a file with `dotrun build-specs` (if you don't have it)
- `dotrun`
- Go to http://0.0.0.0:8104/
- Does it work just the same?