### PR TITLE
catch exceptions while getting spec comments

### DIFF
--- a/webapp/update.py
+++ b/webapp/update.py
@@ -65,12 +65,12 @@ def update_sheet() -> None:
             ),
         )
         for file in files:
-            comments = drive.get_comments(
-                file_id=file["id"], fields=("resolved",)
-            )
-            open_comments = [c for c in comments if not c["resolved"]]
-
             try:
+                comments = drive.get_comments(
+                    file_id=file["id"], fields=("resolved",)
+                )
+                open_comments = [c for c in comments if not c["resolved"]]
+
                 parsed_doc = Spec(google_drive=drive, document_id=file["id"])
             except Exception as e:
                 print(f"Unable to parse document: {file['name']}", e)


### PR DESCRIPTION
## Done

We're getting 503 erros when trying to get the comments from a given document, same every time. Since this was not inside the `try/except` block, it was causing the cronjob to fail.

Let's catch it and continue for now, so it doesn't interrupt the cronjob. An let's see if there's an underlying issue in the meantime. 
 
