### PR TITLE
initialise empty specs list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ credentials.json
 
 # tests
 coverage/
+
+# specs file
+specs.json

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # [specs.canonical.com](https://specs.canonical.com/)
 
-A simple website to visualise Canonical specification documents stored in Google Drive. It allows filtering by different categories (status, team, etc.) as well as seeing a preview of the document. 
+A simple website to visualise Canonical specification documents stored in Google Drive. It allows filtering by different categories (status, team, etc.) as well as seeing a preview of the document.
 
 ## Bugs and issues
 
 If you have found a bug on the site or have an idea for a new feature, feel free to create a new issue, or suggest a fix by creating a pull request.
-
 
 ## Local development
 
@@ -20,6 +19,12 @@ PRIVATE_KEY_ID=...
 PRIVATE_KEY=...
 ```
 
+Generate the specs json file reading data from the spreadsheet:
+
+```
+dotrun build-specs
+```
+
 Run the project with:
 
 ```
@@ -27,4 +32,3 @@ dotrun
 ```
 
 Once the server has started, you can visit http://127.0.0.1:8104 in your browser.
-

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,4 +1,4 @@
-import copy 
+import copy
 import json
 import os
 
@@ -27,6 +27,7 @@ app = FlaskBase(
 init_sso(app)
 
 SPECS_FILE = "specs.json"
+all_specs = []
 if os.path.exists(SPECS_FILE):
     with open(SPECS_FILE) as f:
         all_specs = json.load(f)

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -21,14 +21,9 @@ SERVICE_ACCOUNT_INFO = {
     ),
 }
 
-is_debug = os.getenv("FLASK_DEBUG")
-if is_debug:
-    # Test spreadsheet
-    TRACKER_SPREADSHEET_ID = "1LMS-ryXXfHCF2s2rJZT63n6SFyXqvYjdIq75OYvZLnw"
-else:
-    # Production spreadsheet
-    TRACKER_SPREADSHEET_ID = "1aKH6petyrzjzw0mgUNQscDhFSfVkbAIEjfH7YBS-bDA"
 
+# Spreadsheet that contains the spec metadatada
+TRACKER_SPREADSHEET_ID = "1aKH6petyrzjzw0mgUNQscDhFSfVkbAIEjfH7YBS-bDA"
 
 TEAMS_FOLDER_ID = "19jxxVn_3n6ZAmFl3DReEVgZjxZnlky4X"
 


### PR DESCRIPTION
## Done

- Initialise `all_specs` to an empty list so accessing the main page doesn't fail if someone doesn't generate the specs first 
- Add instructions in README


## QA

- Make sure you don't have a `specs.json` file
- Run the project with `dotrun`
- Go to http://0.0.0.0:8104/ and check a page without specs is displayed
- Now build the json file: `dotrun build-specs`
- Start the local server again with `dotrun`
- Go to http://0.0.0.0:8104/ and check that specs are shown.

## Issue

Fixes #145 
