### PR TITLE
fix: don't show comments on the spec card

### DIFF
--- a/client/SpecCard.tsx
+++ b/client/SpecCard.tsx
@@ -69,14 +69,6 @@ const SpecCard = ({ spec }: { spec: Spec }) => {
             <small>
               <em>{spec.authors.join(", ")}</em>
             </small>
-            <p className="p-card__content">
-              <i className="p-icon--comments">Comments</i>
-              <small className="u-text--muted">
-                {` ${spec.numberOfComments} comments ${
-                  spec.openComments > 0 ? `${spec.openComments} unresolved` : ""
-                }`}
-              </small>
-            </p>
           </div>
           <div className="spec-card__footer p-card__inner">
             <em className="u-align--right">{lastEdited}</em>

--- a/client/styles.scss
+++ b/client/styles.scss
@@ -3,7 +3,6 @@ $increase-font-size-on-larger-screens: false;
 
 @import "vanilla-framework";
 @include vanilla;
-@include vf-p-icon-comments;
 
 main {
   padding-bottom: $spv--strip-regular;

--- a/client/tests/SpecCard.test.tsx
+++ b/client/tests/SpecCard.test.tsx
@@ -12,8 +12,6 @@ describe("renders spec card component", () => {
   it("displays spec details on the card", () => {
     const specTitle = screen.getByText("test_title");
     expect(specTitle).toBeInTheDocument();
-    const comments = screen.getByText("10 comments 5 unresolved");
-    expect(comments).toBeInTheDocument();
     const specIndex = screen.getByText("AB123");
     expect(specIndex).toBeInTheDocument();
     const specStatus = screen.getByText("active");


### PR DESCRIPTION
If we can't count them then don't lie about there being none.

Fixes: #135