### PR TITLE
fix: don't fall over if the tmp sheet has beeen renamed

### DIFF
--- a/webapp/google.py
+++ b/webapp/google.py
@@ -118,6 +118,20 @@ class Sheets:
             spreadsheetId=self.spreadsheet_id, body=body
         ).execute()
 
+    def ensure_sheet_by_title(self, title, *args, **kwargs) -> dict:
+        """
+        Returns an existing sheet matching the title if it can be found, else create it.
+        """
+        try:
+            return self.get_sheet_by_title(title, *args, **kwargs)
+        except StopIteration:
+            # no sheet found with that name
+            body = {
+                "requests": [{"addSheet": {"properties": {"title": title}}}]
+            }
+            self._batch_update(body)
+            return self.get_sheet_by_title(title, *args, **kwargs)
+
     def get_sheet_by_title(self, title, ranges=None) -> dict:
         """
         Return sheet with a given title

--- a/webapp/update.py
+++ b/webapp/update.py
@@ -17,7 +17,7 @@ def update_sheet() -> None:
     sheets = Sheets(spreadsheet_id=TRACKER_SPREADSHEET_ID)
 
     specs_sheet = sheets.get_sheet_by_title(SPECS_SHEET_TITLE)
-    tmp_sheet = sheets.get_sheet_by_title(TMP_SHEET_TITLE)
+    tmp_sheet = sheets.ensure_sheet_by_title(TMP_SHEET_TITLE)
 
     sheets.clear(sheet_id=tmp_sheet["properties"]["sheetId"])
 


### PR DESCRIPTION
Note the failure in https://sentry.is.canonical.com/canonical/specs-canonical-com/issues/33591/

See how the spec update process has been failing for days due to an innocuous change of sheet title in the backing Google Sheet.

Since we just get this sheet and clear it straight away, if we can't find it we should just make it.