### PR TITLE
Fix find files pagination fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 static
+
+# python dependencies
+.venv
+
 # [generated] Bracketed sections updated by Yeoman generator
 # generator-canonical-webteam@3.4.1
 

--- a/webapp/google.py
+++ b/webapp/google.py
@@ -48,8 +48,7 @@ class Drive:
         return html
 
     def get_files(self, query, fields=None):
-        fields = f"files({','.join(fields)})" if fields else None
-
+        fields = f"nextPageToken, files({','.join(fields)})" if fields else None
         page_token = None
         files = []
         while True:
@@ -59,6 +58,7 @@ class Drive:
                     supportsAllDrives=True,
                     includeItemsFromAllDrives=True,
                     fields=fields,
+                    pageToken=page_token,
                     q=query,
                 )
                 .execute()

--- a/webapp/google.py
+++ b/webapp/google.py
@@ -48,7 +48,9 @@ class Drive:
         return html
 
     def get_files(self, query, fields=None):
-        fields = f"nextPageToken, files({','.join(fields)})" if fields else None
+        fields = f"files({','.join(fields)})" if fields else None
+        fields = f"nextPageToken, {fields}" if fields else "nextPageToken"
+
         page_token = None
         files = []
         while True:

--- a/webapp/spec.py
+++ b/webapp/spec.py
@@ -56,7 +56,8 @@ class Spec:
 
     def parse_metadata(self):
         table = self.html.select_one("table")
-
+        if not table:
+            raise ValueError("No metadata table found in document")
         for table_row in table.select("tr"):
             cells = table_row.select("td")
             # invalid format | name | value |, ignoring the row

--- a/webapp/update.py
+++ b/webapp/update.py
@@ -41,6 +41,8 @@ def _generate_spec_rows_for_folders(drive: Drive, folders: List[Dict]):
                 "webViewLink",
             ),
         )
+        print(f"Found {len(files)} documents in {folder['name']}")
+
         for file_ in files:
             try:
                 comments = drive.get_comments(


### PR DESCRIPTION
## Done

- Fix pagination issue in drive files fetching: [official docs example](https://developers.google.com/drive/api/guides/search-files#python).

## QA

- Check out this feature branch
- Apply this modification to the file `settings.py(line: 33)`: `TMP_SHEET_TITLE = "Specs_test"`
- Apply this modification to the file `update.py`: https://pastebin.canonical.com/p/4xX44RrRBd/
  - This will avoid replacing the actual specs sheet at the end of the task
  - Uncomment the part `Uncomment to remove sheet` to delete the sheet at the end of testing
- Run the command locally using the command `dotrun exec flask update-spreadsheet`
- Make sure that some teams have more than 100 items (max items is 100 per page)

## Issue / Card

Fixes #176 
