### PR TITLE
only fetch and parse docs that have been modified

### DIFF
--- a/webapp/update.py
+++ b/webapp/update.py
@@ -29,7 +29,7 @@ except ImportError:
 def _generate_spec_rows_for_folders(
     drive: Drive,
     folders: List[Dict],
-    existingSpecs: Dict[str, List],
+    existing_specs: Dict[str, List],
 ):
     """
     Generate rows for the spreadsheet with the metadata of the specs
@@ -37,7 +37,7 @@ def _generate_spec_rows_for_folders(
 
     :param drive: Drive instance
     :param folders: List of folders
-    :param existingSpecs: Dict of existing specs in the sheet
+    :param existing_specs: Dict of existing specs in the sheet
       key is file id, value is the row in the sheet
     """
     for folder in folders:
@@ -58,11 +58,11 @@ def _generate_spec_rows_for_folders(
         print(f"Found {len(files)} documents in {folder['name']}")
 
         for file_ in files:
-            if file_["id"] in existingSpecs:
+            if file_["id"] in existing_specs:
                 file_modification_date = datetime.datetime.fromisoformat(
                     file_["modifiedTime"][:-1]
                 )
-                row = existingSpecs.get(file_["id"])
+                row = existing_specs.get(file_["id"])
                 previous_modified_date = row["values"][10]["formattedValue"]
                 previous_modified_date = datetime.datetime.fromisoformat(
                     previous_modified_date[:-1]
@@ -72,44 +72,41 @@ def _generate_spec_rows_for_folders(
                     # use the same row as before
                     try:
                         new_row = [
-                            row["values"][i].get("formattedValue", "")
-                            for i in range(len(row["values"]))
+                            value.get("formattedValue", "")
+                            for value in row["values"]
                         ]
                         yield new_row
-                    except Exception as e:
+                    except KeyError as e:
                         print(
                             "something went wrong with file ", file_["name"], e
                         )
 
-            else:
-                try:
-                    comments = drive.get_comments(
-                        file_id=file_["id"], fields=("resolved",)
-                    )
-                    open_comments = [c for c in comments if not c["resolved"]]
-                    parsed_doc = Spec(
-                        google_drive=drive, document_id=file_["id"]
-                    )
-                except Exception as e:
-                    print(f"Unable to parse document: {file_['name']}", e)
-                    continue
+            try:
+                comments = drive.get_comments(
+                    file_id=file_["id"], fields=("resolved",)
+                )
+                open_comments = [c for c in comments if not c["resolved"]]
+                parsed_doc = Spec(google_drive=drive, document_id=file_["id"])
+            except Exception as e:
+                print(f"Unable to parse document: {file_['name']}", e)
+                continue
 
-                row = [
-                    folder["name"],
-                    file_["name"],
-                    file_["id"],
-                    file_["webViewLink"],
-                    parsed_doc.metadata["index"],
-                    parsed_doc.metadata["title"],
-                    parsed_doc.metadata["status"],
-                    ", ".join(parsed_doc.metadata["authors"]),
-                    parsed_doc.metadata["type"],
-                    file_["createdTime"],
-                    file_["modifiedTime"],
-                    len(comments),
-                    len(open_comments),
-                ]
-                yield row
+            row = [
+                folder["name"],
+                file_["name"],
+                file_["id"],
+                file_["webViewLink"],
+                parsed_doc.metadata["index"],
+                parsed_doc.metadata["title"],
+                parsed_doc.metadata["status"],
+                ", ".join(parsed_doc.metadata["authors"]),
+                parsed_doc.metadata["type"],
+                file_["createdTime"],
+                file_["modifiedTime"],
+                len(comments),
+                len(open_comments),
+            ]
+            yield row
 
 
 def update_sheet() -> None:
@@ -159,20 +156,22 @@ def update_sheet() -> None:
     )
     folders = drive.get_files(query=query_subfolders, fields=("id", "name"))
 
-    current_specs = {}
+    existing_specs = {}
 
     spec_rows = specs_sheet.get("data", [{}])[0].get("rowData", [])
 
+    # create a dict with the existing specs in the sheet, ignore the header
     for row in spec_rows[1:]:
         try:
-            current_specs[row["values"][2]["formattedValue"]] = row
-        except Exception as e:
+            file_id = row["values"][2]["formattedValue"]
+            existing_specs[file_id] = row
+        except (KeyError, IndexError) as e:
             print("Error parsing row", e)
 
     # Insert rows in batches of 25, which is a magic number with no science
     # behind it.
     for rows in batched(
-        _generate_spec_rows_for_folders(drive, folders, current_specs),
+        _generate_spec_rows_for_folders(drive, folders, existing_specs),
         25,
     ):
         _append_rows(rows=rows)

--- a/webapp/update.py
+++ b/webapp/update.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+import datetime
 
 import tenacity
 
@@ -25,7 +26,20 @@ except ImportError:
             yield batch
 
 
-def _generate_spec_rows_for_folders(drive: Drive, folders: List[Dict]):
+def _generate_spec_rows_for_folders(
+    drive: Drive,
+    folders: List[Dict],
+    existingSpecs: Dict[str, List],
+):
+    """
+    Generate rows for the spreadsheet with the metadata of the specs
+    found in the folders.
+
+    :param drive: Drive instance
+    :param folders: List of folders
+    :param existingSpecs: Dict of existing specs in the sheet
+      key is file id, value is the row in the sheet
+    """
     for folder in folders:
         query_doc_files = (
             f"mimeType = 'application/vnd.google-apps.document' "
@@ -44,32 +58,58 @@ def _generate_spec_rows_for_folders(drive: Drive, folders: List[Dict]):
         print(f"Found {len(files)} documents in {folder['name']}")
 
         for file_ in files:
-            try:
-                comments = drive.get_comments(
-                    file_id=file_["id"], fields=("resolved",)
+            if file_["id"] in existingSpecs:
+                file_modification_date = datetime.datetime.fromisoformat(
+                    file_["modifiedTime"][:-1]
                 )
-                open_comments = [c for c in comments if not c["resolved"]]
-                parsed_doc = Spec(google_drive=drive, document_id=file_["id"])
-            except Exception as e:
-                print(f"Unable to parse document: {file_['name']}", e)
-                continue
+                row = existingSpecs.get(file_["id"])
+                previous_modified_date = row["values"][10]["formattedValue"]
+                previous_modified_date = datetime.datetime.fromisoformat(
+                    previous_modified_date[:-1]
+                )
+                if previous_modified_date >= file_modification_date:
+                    # file has not been modified since last update
+                    # use the same row as before
+                    try:
+                        new_row = [
+                            row["values"][i].get("formattedValue", "")
+                            for i in range(len(row["values"]))
+                        ]
+                        yield new_row
+                    except Exception as e:
+                        print(
+                            "something went wrong with file ", file_["name"], e
+                        )
 
-            row = [
-                folder["name"],
-                file_["name"],
-                file_["id"],
-                file_["webViewLink"],
-                parsed_doc.metadata["index"],
-                parsed_doc.metadata["title"],
-                parsed_doc.metadata["status"],
-                ", ".join(parsed_doc.metadata["authors"]),
-                parsed_doc.metadata["type"],
-                file_["createdTime"],
-                file_["modifiedTime"],
-                len(comments),
-                len(open_comments),
-            ]
-            yield row
+            else:
+                try:
+                    comments = drive.get_comments(
+                        file_id=file_["id"], fields=("resolved",)
+                    )
+                    open_comments = [c for c in comments if not c["resolved"]]
+                    parsed_doc = Spec(
+                        google_drive=drive, document_id=file_["id"]
+                    )
+                except Exception as e:
+                    print(f"Unable to parse document: {file_['name']}", e)
+                    continue
+
+                row = [
+                    folder["name"],
+                    file_["name"],
+                    file_["id"],
+                    file_["webViewLink"],
+                    parsed_doc.metadata["index"],
+                    parsed_doc.metadata["title"],
+                    parsed_doc.metadata["status"],
+                    ", ".join(parsed_doc.metadata["authors"]),
+                    parsed_doc.metadata["type"],
+                    file_["createdTime"],
+                    file_["modifiedTime"],
+                    len(comments),
+                    len(open_comments),
+                ]
+                yield row
 
 
 def update_sheet() -> None:
@@ -119,9 +159,22 @@ def update_sheet() -> None:
     )
     folders = drive.get_files(query=query_subfolders, fields=("id", "name"))
 
+    current_specs = {}
+
+    spec_rows = specs_sheet.get("data", [{}])[0].get("rowData", [])
+
+    for row in spec_rows[1:]:
+        try:
+            current_specs[row["values"][2]["formattedValue"]] = row
+        except Exception as e:
+            print("Error parsing row", e)
+
     # Insert rows in batches of 25, which is a magic number with no science
     # behind it.
-    for rows in batched(_generate_spec_rows_for_folders(drive, folders), 25):
+    for rows in batched(
+        _generate_spec_rows_for_folders(drive, folders, current_specs),
+        25,
+    ):
         _append_rows(rows=rows)
 
     # Rename temporary file as the main one once it contains all the specs


### PR DESCRIPTION
## Done

- Only parse and fetch comments for docs that have been modified. if not modified use old data

## QA

- Check out this feature branch
- Apply this modification to the file `settings.py(line: 33)`: `TMP_SHEET_TITLE = "Specs_test"`
- Apply this modification to the file `update.py`: https://pastebin.canonical.com/p/4xX44RrRBd/
  - This will avoid replacing the actual specs sheet at the end of the task
  - Uncomment the part `Uncomment to remove sheet` to delete the sheet at the end of testing
- Run the command locally using the command `dotrun exec flask update-spreadsheet`
- Make sure that all the specs are there and no edge cases aren't handled 
