### PR TITLE
Improve specs list UI performance

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -5,8 +5,15 @@ import SpecCard from "./SpecCard";
 import { Spec, Team } from "./types";
 import { useFilteredAndSortedSpecs } from "./UserFilterOptions";
 import { sortSet } from "./utils";
+import SpecCardsList from "./SpecCardsList";
 
-export const specTypes = new Set(["Implementation", "Product Requirement", "Standard", "Informational", "Process"]);
+export const specTypes = new Set([
+  "Implementation",
+  "Product Requirement",
+  "Standard",
+  "Informational",
+  "Process",
+]);
 export const specStatuses = new Set([
   "active",
   "approved",
@@ -89,15 +96,7 @@ function App({ specs, teams }: { specs: Spec[]; teams: Team[] }) {
             defaultOptions={filter}
           />
         </div>
-        <div className="l-fluid-breakout__main" id="cards">
-          {filteredSpecs.length ? (
-            filteredSpecs.map((spec, i) => <SpecCard key={i} spec={spec} />)
-          ) : (
-            <h2 id="no-results" className="u-hide u-align-text--center">
-              No specs found
-            </h2>
-          )}
-        </div>
+        <SpecCardsList specs={filteredSpecs} />
       </main>
       <footer className="p-strip is-shallow">
         <div className="row">

--- a/client/SpecCard.tsx
+++ b/client/SpecCard.tsx
@@ -1,9 +1,15 @@
-import React, { useState } from "react";
 import clsx from "clsx";
-import { Spec } from "./types";
+import React, { useState } from "react";
 import SpecsDetails from "./SpecsDetails";
+import { Spec } from "./types";
 
-const SpecCard = ({ spec }: { spec: Spec }) => {
+const SpecCard = ({
+  spec,
+  style,
+}: {
+  spec: Spec;
+  style: React.CSSProperties;
+}) => {
   const [viewSpecsDetails, setViewSpecsDetails] = useState<boolean>(false);
   const lastEdited = `Last edit: ${spec.lastUpdated.toLocaleDateString(
     "en-GB",
@@ -16,9 +22,9 @@ const SpecCard = ({ spec }: { spec: Spec }) => {
 
   return (
     <>
-      <div className="l-fluid-breakout__item" data-js="grid-item">
+      <div data-js="grid-item" style={style}>
         <div
-          className={`spec-card spec-card--${spec.status.toLowerCase()} p-card col-4 u-no-padding`}
+          className={`spec-card spec-card--${spec.status.toLowerCase()} p-card col-4`}
         >
           <div className="spec-card__content p-card__inner">
             <div className="spec-card__header">

--- a/client/SpecCard.tsx
+++ b/client/SpecCard.tsx
@@ -24,7 +24,7 @@ const SpecCard = ({
     <>
       <div data-js="grid-item" style={style}>
         <div
-          className={`spec-card spec-card--${spec.status.toLowerCase()} p-card col-4`}
+          className={`spec-card spec-card--${spec.status.toLowerCase()} p-card col-4 u-no-padding`}
         >
           <div className="spec-card__content p-card__inner">
             <div className="spec-card__header">

--- a/client/SpecCardsList.tsx
+++ b/client/SpecCardsList.tsx
@@ -25,9 +25,9 @@ const SpecCardsList = ({ specs }: SpecCardsListProps) => {
     >
       <VirtualizedGrid
         items={specs}
-        itemHeight={270}
+        itemHeight={230}
         itemMinWidth={400}
-        gridSpace={6}
+        gridSpace={16}
         renderItem={(props: VirtualizedGridItemProps<Spec>) =>
           specs[props.index] ? (
             <div>

--- a/client/SpecCardsList.tsx
+++ b/client/SpecCardsList.tsx
@@ -28,11 +28,15 @@ const SpecCardsList = ({ specs }: SpecCardsListProps) => {
         itemHeight={270}
         itemMinWidth={400}
         gridSpace={6}
-        renderItem={(props: VirtualizedGridItemProps<Spec>) => (
-          <div>
-            <SpecCard spec={specs[props.index]} style={props.style} />
-          </div>
-        )}
+        renderItem={(props: VirtualizedGridItemProps<Spec>) =>
+          specs[props.index] ? (
+            <div>
+              <SpecCard spec={specs[props.index]} style={props.style} />
+            </div>
+          ) : (
+            <></>
+          )
+        }
       />
     </div>
   );

--- a/client/SpecCardsList.tsx
+++ b/client/SpecCardsList.tsx
@@ -1,0 +1,41 @@
+import SpecCard from "./SpecCard";
+import { Spec } from "./types";
+import VirtualizedGrid, { VirtualizedGridItemProps } from "./VirtualGrid";
+
+interface SpecCardsListProps {
+  specs: Spec[];
+}
+
+const SpecCardsList = ({ specs }: SpecCardsListProps) => {
+  if (!specs.length) {
+    return (
+      <div className="l-fluid-breakout__main">
+        <h2 id="no-results" className="u-align-text--center">
+          No specs found
+        </h2>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="l-fluid-breakout__main"
+      // full width child as the grid is handled by the VirtualizedGrid component
+      style={{ gridTemplateColumns: "1fr" }}
+    >
+      <VirtualizedGrid
+        items={specs}
+        itemHeight={270}
+        itemMinWidth={400}
+        gridSpace={6}
+        renderItem={(props: VirtualizedGridItemProps<Spec>) => (
+          <div>
+            <SpecCard spec={specs[props.index]} style={props.style} />
+          </div>
+        )}
+      />
+    </div>
+  );
+};
+
+export default SpecCardsList;

--- a/client/VirtualGrid/index.scss
+++ b/client/VirtualGrid/index.scss
@@ -1,0 +1,11 @@
+.ReactVirtualized__container {
+  flex: 1;
+  > div {
+    height: unset !important;
+  }
+
+  .ReactVirtualized__Grid,
+  .ReactVirtualized__Grid__innerScrollContainer {
+    overflow: visible !important;
+  }
+}

--- a/client/VirtualGrid/index.tsx
+++ b/client/VirtualGrid/index.tsx
@@ -82,6 +82,12 @@ function VirtualizedGrid<ItemType>({
                   scrollTop={scrollTop}
                   onScroll={onChildScroll}
                   cellRenderer={(props: GridCellProps) => {
+                    const isLastColumn = props.columnIndex === columnCount - 1;
+                    const isLastRow = props.rowIndex === rowCount - 1;
+                    const isLastItem =
+                      props.rowIndex * columnCount + props.columnIndex >=
+                      items.length - 1;
+
                     const fullProps: VirtualizedGridItemProps<ItemType> = {
                       ...props,
                       items,
@@ -91,7 +97,11 @@ function VirtualizedGrid<ItemType>({
                         ...props.style,
                         width: itemWidth,
                         height: itemHeight,
-                        padding: `0 ${gridSpace}px ${gridSpace}px 0`,
+                        marginRight: !isLastColumn ? gridSpace : 0,
+                        marginBottom: !isLastRow && !isLastItem ? gridSpace : 0,
+                        left: props.style.left as number,
+                        top: props.style.top as number,
+                        position: "absolute",
                       },
                     };
                     return renderItem(fullProps);
@@ -105,4 +115,5 @@ function VirtualizedGrid<ItemType>({
     </div>
   );
 }
+
 export default VirtualizedGrid;

--- a/client/VirtualGrid/index.tsx
+++ b/client/VirtualGrid/index.tsx
@@ -1,0 +1,108 @@
+import { FC, useEffect, useRef } from "react";
+import {
+  AutoSizer as _AutoSizer,
+  Grid as _Grid,
+  WindowScroller as _WindowScroller,
+  AutoSizerProps,
+  GridCellProps,
+  GridProps,
+  WindowScrollerProps,
+} from "react-virtualized";
+import useWindowSize from "../hooks/useWindowSize";
+import "./index.scss";
+
+export interface VirtualizedGridItemProps<ItemType> extends GridCellProps {
+  items: ItemType[];
+  columnCount: number;
+  index: number;
+}
+const Grid = _Grid as unknown as FC<GridProps>;
+const WindowScroller = _WindowScroller as unknown as FC<WindowScrollerProps>;
+const AutoSizer = _AutoSizer as unknown as FC<AutoSizerProps>;
+
+interface VirtualizedGridProps<ItemType> {
+  items: ItemType[];
+  itemHeight: number;
+  itemMinWidth: number;
+  gridSpace?: number;
+  renderItem: (props: VirtualizedGridItemProps<ItemType>) => JSX.Element;
+  numColumns?: number;
+}
+
+function VirtualizedGrid<ItemType>({
+  items,
+  renderItem,
+  itemHeight,
+  itemMinWidth,
+  numColumns,
+  gridSpace = 0,
+}: VirtualizedGridProps<ItemType>): JSX.Element {
+  const gridRef = useRef<any>(null);
+  const containerRef = useRef<any>(null);
+  const containerWidth = containerRef?.current?.clientWidth;
+
+  const windowSize = useWindowSize();
+
+  useEffect(() => {
+    gridRef.current?.recomputeGridSize();
+  }, [windowSize]);
+
+  function calculateColumnCount(width: number) {
+    const totalSpace = gridSpace * (Math.floor(width / itemMinWidth) - 1);
+    return Math.floor((width - totalSpace) / itemMinWidth);
+  }
+
+  function calculateItemWidth(width: number, columnCount: number) {
+    const totalSpace = gridSpace * (columnCount - 1);
+    return (width - totalSpace) / columnCount;
+  }
+
+  return (
+    <div className="ReactVirtualized__container" ref={containerRef}>
+      <WindowScroller>
+        {({ height, isScrolling, onChildScroll, scrollTop }) => (
+          <AutoSizer disableHeight>
+            {() => {
+              const columnCount =
+                numColumns ?? calculateColumnCount(containerWidth);
+              const rowCount = Math.ceil(items.length / columnCount);
+              const itemWidth = calculateItemWidth(containerWidth, columnCount);
+
+              return (
+                <Grid
+                  ref={gridRef}
+                  autoHeight
+                  columnCount={columnCount}
+                  columnWidth={itemWidth + gridSpace}
+                  width={containerWidth}
+                  height={height}
+                  rowCount={rowCount}
+                  rowHeight={itemHeight + gridSpace}
+                  isScrolling={isScrolling}
+                  scrollTop={scrollTop}
+                  onScroll={onChildScroll}
+                  cellRenderer={(props: GridCellProps) => {
+                    const fullProps: VirtualizedGridItemProps<ItemType> = {
+                      ...props,
+                      items,
+                      columnCount: columnCount,
+                      index: props.rowIndex * columnCount + props.columnIndex,
+                      style: {
+                        ...props.style,
+                        width: itemWidth,
+                        height: itemHeight,
+                        padding: `0 ${gridSpace}px ${gridSpace}px 0`,
+                      },
+                    };
+                    return renderItem(fullProps);
+                  }}
+                />
+              );
+            }}
+          </AutoSizer>
+        )}
+      </WindowScroller>
+    </div>
+  );
+}
+export default VirtualizedGrid;

--- a/client/hooks/useWindowSize.ts
+++ b/client/hooks/useWindowSize.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+type WindowSize = [number, number];
+
+export const useWindowSize = (): WindowSize => {
+  const initSize: WindowSize = [window.innerWidth, window.innerHeight];
+  const [windowSize, setWindowSize] = useState<WindowSize>(initSize);
+
+  useEffect(() => {
+    const handleResize = (): void => {
+      setWindowSize([window.innerWidth, window.innerHeight]);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return windowSize;
+};
+
+export default useWindowSize;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "qs": "^6.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-virtualized": "^9.22.5",
     "sass": "1.57.1",
     "vanilla-framework": "3.15.1"
   },
@@ -38,6 +39,7 @@
     "@types/qs": "^6.9.7",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "@types/react-virtualized": "^9.21.30",
     "@vitejs/plugin-react": "^3.0.0",
     "babel-jest": "^29.0.0",
     "jest": "^29.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz"
@@ -1773,6 +1780,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-virtualized@^9.21.30":
+  version "9.21.30"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.30.tgz#ba39821bcb2487512a8a2cdd9fbdb5e6fc87fedb"
+  integrity sha512-4l2TFLQ8BCjNDQlvH85tU6gctuZoEdgYzENQyZHpgTHU7hoLzYgPSOALMAeA58LOWua8AzC6wBivPj1lfl6JgQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.0.15":
   version "18.0.15"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz"
@@ -2198,7 +2213,7 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clsx@^1.2.1:
+clsx@^1.0.4, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -2403,6 +2418,14 @@ dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.14"
   resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz"
   integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
+
+dom-helpers@^5.1.3:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 domexception@^4.0.0:
   version "4.0.0"
@@ -3817,7 +3840,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15.8.1:
+prop-types@15.8.1, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -3876,6 +3899,11 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
 react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz"
@@ -3892,6 +3920,18 @@ react-useportal@1.0.18:
   integrity sha512-dGuT/yyE2T9RtUxRZJYkIX8tLHC7KxAxbMw/Ufjiwo8ixoDYzkk9LFKGnARtCtFz6Yd5AoP7fVymrN3eT04jiA==
   dependencies:
     use-ssr "^1.0.25"
+
+react-virtualized@^9.22.5:
+  version "9.22.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.5.tgz#bfb96fed519de378b50d8c0064b92994b3b91620"
+  integrity sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@^18.2.0:
   version "18.2.0"
@@ -3931,6 +3971,11 @@ regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.15.0:
   version "0.15.0"


### PR DESCRIPTION
## Done

- Improve the UI performance by only loading to the DOM the items that are in viewport

## QA

- Check out this feature branch
- View the site in your web browser at: https://specs-canonical-com-184.demos.haus/
- Make sure that the spec cards are shown properly
- Make a filter query
- Make sure that after filtering is done, specs are showing properly
- Resize the window
- Make sure that the specs list is responsive

