### PR TITLE
Use JsonLines format so we can read the specs file line by line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ cachetools==5.3.0
 black==23.1.0
 flake8==6.0.0
 tenacity==8.2.3
+jsonlines

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,13 +1,14 @@
 import logging
 
 import flask
+import jsonlines
 from cachetools import TTLCache, cached
 from canonicalwebteam.flask_base.app import FlaskBase
 from flask import abort, jsonify, redirect, render_template
 
 from webapp.authors import parse_authors, unify_authors
-from webapp.build_specs import save_specs_locally
 from webapp.google import Drive
+from webapp.settings import SPECS_FILE
 from webapp.spec import Spec
 from webapp.sso import init_sso
 from webapp.update import update_sheet
@@ -30,11 +31,13 @@ app = FlaskBase(
 init_sso(app)
 
 
-# Cache for 30 minutes
-@cached(cache=TTLCache(maxsize=128, ttl=CACHE_TTL))
 def all_specs():
-    # load the specs from the sheet and save them locally
-    return save_specs_locally()
+    try:
+        with jsonlines.open(SPECS_FILE) as reader:
+            for obj in reader:
+                yield obj
+    except FileNotFoundError:
+        return []
 
 
 @app.route("/")

--- a/webapp/build_specs.py
+++ b/webapp/build_specs.py
@@ -1,8 +1,7 @@
-import json
 import logging
 from datetime import datetime
-from typing import Dict, List
 
+import jsonlines
 from webapp.google import Sheets
 from webapp.settings import (
     SPECS_FILE,
@@ -72,12 +71,6 @@ def generate_specs(sheet):
             yield spec
 
 
-def save_specs(specs):
-    with open(SPECS_FILE, "w") as f:
-        logger.info("Saved %s specs to specs.json", len(specs))
-        json.dump(specs, f, indent=4)
-
-
 def load_sheet():
     spreadsheet = Sheets(spreadsheet_id=TRACKER_SPREADSHEET_ID)
 
@@ -89,7 +82,7 @@ def load_sheet():
     return sheet
 
 
-def save_specs_locally() -> List[Dict]:
+def save_specs_locally():
     """
     Fetch already parsed specs from Google Sheets and save them locally.
 
@@ -97,10 +90,10 @@ def save_specs_locally() -> List[Dict]:
     """
     logger.info("Fetching specs from Google Sheets")
     sheet = load_sheet()
-    specs = list(generate_specs(sheet))
-    save_specs(specs)
-    print(specs[0])
-    return specs
+
+    with jsonlines.open(SPECS_FILE, mode="w") as writer:
+        for spec in generate_specs(sheet):
+            writer.write(spec)
 
 
 if __name__ == "__main__":

--- a/webapp/update.py
+++ b/webapp/update.py
@@ -2,11 +2,13 @@ import datetime
 import logging
 from typing import Dict, List
 
+import jsonlines
 import tenacity
 
 from webapp.build_specs import save_specs_locally
 from webapp.google import Drive, Sheets
 from webapp.settings import (
+    SPECS_FILE,
     SPECS_SHEET_TITLE,
     TEAMS_FOLDER_ID,
     TMP_SHEET_TITLE,
@@ -134,6 +136,8 @@ def update_sheet() -> None:
     specs_sheet = sheets.get_sheet_by_title(SPECS_SHEET_TITLE)
     tmp_sheet = sheets.ensure_sheet_by_title(TMP_SHEET_TITLE)
 
+    save_specs_locally()
+
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(3),
         wait=tenacity.wait_incrementing(start=0.5, increment=0.8),
@@ -173,7 +177,10 @@ def update_sheet() -> None:
     logger.info("Found %s subfolders", len(folders))
 
     # create a dict with the existing specs in the sheet, ignore the header
-    existing_specs = {spec["fileID"]: spec for spec in save_specs_locally()}
+    existing_specs = {}
+    with jsonlines.open(SPECS_FILE) as reader:
+        for spec in reader:
+            existing_specs = existing_specs[spec["fileID"]] = spec
 
     logger.info(
         "Found %s existing specs in the current sheet",


### PR DESCRIPTION
## Done

Use JsonLines format so we can read the specs file line by line

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8104/
- Test the different features and make sure everything works